### PR TITLE
UILabel subclass AdjustableLabel fixes truncation in tutorial

### DIFF
--- a/Endless/AdjustableLabel.h
+++ b/Endless/AdjustableLabel.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017, Psiphon Inc.
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+// Based on: http://stackoverflow.com/questions/2844397/how-to-adjust-font-size-of-label-to-fit-the-rectangle/33657604#33657604
+
+
+#import <UIKit/UIKit.h>
+
+@interface AdjustableLabel : UILabel
+/**
+ If set to YES, font size will be automatically adjusted to frame.
+ Note: numberOfLines can't be specified so it will be set to 0.
+ */
+@property(nonatomic) BOOL adjustsFontSizeToFitFrame;
+@property(nonatomic) CGFloat desiredFontSize;
+- (id)initWithDesiredFontSize:(CGFloat)fontSize;
+@end

--- a/Endless/AdjustableLabel.m
+++ b/Endless/AdjustableLabel.m
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2017, Psiphon Inc.
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Based on http://stackoverflow.com/questions/2844397/how-to-adjust-font-size-of-label-to-fit-the-rectangle/33657604#33657604
+
+
+#import "AdjustableLabel.h"
+
+@interface AdjustableLabel ()
+@property(nonatomic) BOOL fontSizeAdjusted;
+@end
+
+// The size found S satisfies: S fits in the frame and and S+DELTA doesn't.
+#define DELTA 0.5
+#define MIN_FONT_SIZE 5.0f
+
+@implementation AdjustableLabel
+
+- (id)initWithDesiredFontSize:(CGFloat)fontSize {
+    self = [super init];
+
+    if (self) {
+        self.desiredFontSize = fontSize;
+    }
+
+    return self;
+}
+
+- (void)setAdjustsFontSizeToFitFrame:(BOOL)adjustsFontSizeToFitFrame
+{
+    _adjustsFontSizeToFitFrame = adjustsFontSizeToFitFrame;
+    
+    if (adjustsFontSizeToFitFrame) {
+        self.numberOfLines = 0; // because boundingRectWithSize works like this was 0 anyway
+    }
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    if (self.adjustsFontSizeToFitFrame)
+    {
+        [self adjustFontSizeToFrame];
+    }
+}
+
+- (void)adjustFontSizeToFrame
+{
+    AdjustableLabel* label = self;
+
+    if (label.text.length == 0) return;
+
+    // Necessary or single-char texts won't be correctly adjusted
+    BOOL checkWidth = label.text.length == 1;
+
+    CGSize labelSize = label.frame.size;
+
+    // Fit label width-wise
+    CGSize constraintSize = CGSizeMake(checkWidth ? MAXFLOAT : labelSize.width, MAXFLOAT);
+
+    // Try all font sizes from desired to smallest font size
+    CGFloat maxFontSize = label.desiredFontSize;
+    CGFloat minFontSize = MIN_FONT_SIZE;
+
+    UIFont *font = label.font;
+    CGFloat fontSize = maxFontSize;
+
+    // Do a binary search to find the largest font size that
+    // will fit within the label's frame.
+    while (true)
+    {
+        fontSize = (maxFontSize + minFontSize) / 2;
+
+        if (fontSize - minFontSize < DELTA / 2) {
+            font = [UIFont fontWithName:font.fontName size:minFontSize];
+            break; // Exit because we reached the biggest font size that fits
+        } else {
+            font = [UIFont fontWithName:font.fontName size:fontSize];
+        }
+
+        NSMutableAttributedString* attributedString = [[NSMutableAttributedString alloc] initWithAttributedString:label.attributedText];
+        [attributedString addAttribute:NSFontAttributeName value:font range:NSMakeRange(0, label.attributedText.length)];
+
+        CGRect rect = [attributedString boundingRectWithSize:constraintSize options:NSStringDrawingUsesLineFragmentOrigin context:nil];
+
+        // Now we discard a half
+        if(rect.size.height <= labelSize.height && (!checkWidth || rect.size.width <= labelSize.width)) {
+            minFontSize = fontSize; // the best size is in the bigger half
+        } else {
+            maxFontSize = fontSize; // the best size is in the smaller half
+        }
+    }
+
+    label.font = font;
+}
+
+@end

--- a/Endless/Tutorial.h
+++ b/Endless/Tutorial.h
@@ -18,6 +18,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "AdjustableLabel.h"
 
 @protocol TutorialDelegate;
 
@@ -34,7 +35,7 @@
 @property (strong, nonatomic) UIButton *skipButton;
 @property (strong, nonatomic) UILabel *headerView;
 @property (strong, nonatomic) UILabel *titleView;
-@property (strong, nonatomic) UILabel *textView;
+@property (strong, nonatomic) AdjustableLabel *textView;
 @property (strong, nonatomic) UIButton *letsGo;
 
 @property (strong, nonatomic) NSArray<NSLayoutConstraint*> *removeBeforeNextStep;

--- a/Endless/Tutorial.m
+++ b/Endless/Tutorial.m
@@ -19,6 +19,7 @@
 
 #import "Tutorial.h"
 
+
 @implementation Tutorial {
     NSArray<NSString*>* _headerText;
     NSArray<NSString*>* _titleText;
@@ -166,7 +167,7 @@
 }
 
 - (void)setupTextView {
-    _textView = [[UILabel alloc] init];
+    _textView = [[AdjustableLabel alloc] initWithDesiredFontSize:16.0f];
 }
 
 - (void)setupArrowView {
@@ -240,10 +241,9 @@
     // Need to reapply
     _textView.textAlignment = NSTextAlignmentCenter;
     _textView.textColor = [UIColor whiteColor];
-    _textView.adjustsFontSizeToFitWidth = YES;
     _textView.font = [UIFont fontWithName:@"HelveticaNeue" size:16.0f];
-    _textView.numberOfLines = 0;
     _textView.backgroundColor = [UIColor clearColor];
+    _textView.adjustsFontSizeToFitFrame = YES;
 }
 
 - (NSString*)getHeaderTextForStep
@@ -279,7 +279,6 @@
                      }
                      completion:^(BOOL finished){
                          _arrowView.transform = CGAffineTransformIdentity;
-                         NSLog(@"constraint: Animation completed");
                      }];
 }
 


### PR DESCRIPTION
UILabel's adjustsFontSizeToFitWidth calculation does not take into account line spacing. Fixed this with UILabel subclass AdjustableLabel which takes linespacing into account when shrinking text to fit.