### PR TITLE
Exit fullscreen after onboarding. Fix modal connection dialog not showing after onboarding/tutorial

### DIFF
--- a/Endless/OnboardingViewController.m
+++ b/Endless/OnboardingViewController.m
@@ -269,6 +269,8 @@
 - (void)onboardingEnded {
     [self.pageController.view removeFromSuperview];
     [self dismissViewControllerAnimated:NO completion:nil];
+
+    [[UIApplication sharedApplication] setStatusBarHidden:NO]; // Exit full screen
     
     id<OnboardingViewControllerDelegate> strongDelegate = self.delegate;
     

--- a/Endless/WebViewController.m
+++ b/Endless/WebViewController.m
@@ -394,8 +394,8 @@
 - (void)viewIsVisible
 {
     static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        if (webViewTabs.count == 0 && ![[AppDelegate sharedAppDelegate] areTesting] && !self.showTutorial) {
+    if (webViewTabs.count == 0 && ![[AppDelegate sharedAppDelegate] areTesting] && !self.showTutorial) {
+        dispatch_once(&onceToken, ^{
             PsiphonConnectionSplashViewController *connectionSplashViewController = [[PsiphonConnectionSplashViewController alloc]
                                                                                      initWithState:[[AppDelegate sharedAppDelegate] psiphonConectionState]];
             connectionSplashViewController.delegate = self;
@@ -407,9 +407,9 @@
             
             [[UIViewController topViewController] presentViewController:connectionSplashViewController animated:NO
                                                              completion:^(){[[AppDelegate sharedAppDelegate] notifyPsiphonConnectionState];}];
-        }
-    });
-    
+        });
+    }
+
     /* in case our orientation changed, or the status bar changed height (which can take a few millis for animation) */
     [self performSelector:@selector(adjustLayout) withObject:nil afterDelay:0.5];
 }
@@ -1479,6 +1479,8 @@
         // Start psiphon and open homepage
         [[AppDelegate sharedAppDelegate] startIfNeeded];
     }
+
+    [self viewIsVisible];
 }
 
 #pragma mark - Tutorial methods and helper functions
@@ -1754,11 +1756,18 @@
     
     /* Start tutorial */
     [tutorial startTutorial];
-    
-    UITapGestureRecognizer *tutorialScreenPress =
+
+    UITapGestureRecognizer *tutorialBlockingViewPress =
     [[UITapGestureRecognizer alloc] initWithTarget:self
                                             action:@selector(handleTutorialClick:)];
-    [self.view addGestureRecognizer:tutorialScreenPress];
+
+    [tutorial.blockingView addGestureRecognizer:tutorialBlockingViewPress];
+
+    UITapGestureRecognizer *tutorialContentViewPress =
+    [[UITapGestureRecognizer alloc] initWithTarget:self
+                                            action:@selector(handleTutorialClick:)];
+
+    [tutorial.contentView addGestureRecognizer:tutorialContentViewPress];
 }
 
 - (void) showPsiphonConnectionStatusAlert {


### PR DESCRIPTION
- Exit fullscreen after onboarding
- Fix modal connection dialog not showing after onboarding/tutorial
- Fix connection indicator not clickable after onboarding/tutorial