### PR TITLE
Address bar URL spoofing fix

### DIFF
--- a/Endless/URLInterceptor.m
+++ b/Endless/URLInterceptor.m
@@ -392,6 +392,10 @@ static NSString *_javascriptToInject;
 	_data = nil;
 	firstChunk = YES;
 
+	if(wvt) {
+		[wvt setUrl:[[self actualRequest] mainDocumentURL]];
+	}
+
 	contentType = CONTENT_TYPE_OTHER;
 	NSString *ctype = [[self caseInsensitiveHeader:@"content-type" inResponse:response] lowercaseString];
 	if (ctype != nil && ([ctype hasPrefix:@"text/html"] || [ctype hasPrefix:@"application/html"] || [ctype hasPrefix:@"application/xhtml+xml"]))

--- a/Endless/WebViewController.m
+++ b/Endless/WebViewController.m
@@ -295,7 +295,6 @@
 	[center addObserver:self selector:@selector(psiphonConnectionStateNotified:) name:kPsiphonConnectionStateNotification object:nil];
 
 	[self adjustLayout];
-	[self updateSearchBarDetails];
 
 	[self.view.window makeKeyAndVisible];
 }
@@ -664,6 +663,7 @@
 	[webViewTabs addObject:wvt];
 	[tabChooser setNumberOfPages:webViewTabs.count];
 	[wvt setTabIndex:[NSNumber numberWithLong:(webViewTabs.count - 1)]];
+	[wvt setUrl:url];
 
 	[tabCount setText:[NSString stringWithFormat:@"%lu", tabChooser.numberOfPages]];
 
@@ -1047,6 +1047,7 @@
 	[urlField resignFirstResponder]; /* will unfocus and call textFieldDidEndEditing */
 
 	if (enteredURL != nil) {
+		[[self curWebViewTab] setUrl:enteredURL];
 		[[self curWebViewTab] loadURL:enteredURL];
 	}
 }

--- a/Endless/WebViewTab.m
+++ b/Endless/WebViewTab.m
@@ -204,11 +204,10 @@
 	[self.title setFrame:CGRectMake(22, -22, frame.size.width - 22 - 22, 18)];
 }
 
-- (void)prepareForNewURL:(NSURL *)URL
+- (void)reset
 {
 	[[self applicableHTTPSEverywhereRules] removeAllObjects];
 	[self setSSLCertificate:nil];
-	[self setUrl:URL];
 }
 
 - (void)loadURL:(NSURL *)u
@@ -235,7 +234,7 @@
 - (void)loadURL:(NSURL *)u withForce:(BOOL)force
 {
 	[self.webView stopLoading];
-	[self prepareForNewURL:u];
+	[self reset];
 
 	NSMutableURLRequest *ur = [NSMutableURLRequest requestWithURL:u];
 	if (force)
@@ -265,6 +264,7 @@
 #ifdef TRACE
 		NSLog(@"[Tab %@] searching via %@", self.tabIndex, url);
 #endif
+		[self setUrl:url];
 		[self loadURL:url];
 	}
 	else {
@@ -284,7 +284,9 @@
 		}
 
 		[self.webView stopLoading];
-		[self prepareForNewURL:url];
+		[self reset];
+		[self setUrl:url];
+
 
 #ifdef TRACE
 		NSLog(@"[Tab %@] searching via POST to %@ (with params %@)", self.tabIndex, url, params);
@@ -327,7 +329,7 @@
 			return NO;
 		}
 		if ([[[request mainDocumentURL] absoluteString] isEqualToString:[[request URL] absoluteString]]) {
-			[self prepareForNewURL:[request mainDocumentURL]];
+			[self reset];
 
 			// Ignore links clicked, forms submitted, reloads, etc.
 			if(navigationType == UIWebViewNavigationTypeOther) {


### PR DESCRIPTION
Set URL to display when there is a HTTP response.
Set URL right away only when:
* A tab is about to load a URL entered from either address bar or bookmarks.
* A new tab is open and is about to load a URL.