### PR TITLE
Reload tabs when 'Disable Javascript' setting is toggled

### DIFF
--- a/Endless/Endless-Prefix.pch
+++ b/Endless/Endless-Prefix.pch
@@ -51,7 +51,7 @@ typedef NS_ENUM(NSInteger, PsiphonConnectionState)
 #define kPsiphonConnectionState @"kPsiphonConnectionState"
 #define kPsiphonAvailableRegionsNotification @"kPsiphonAvailableRegionsNotification"
 #define kPsiphonRegionBestPerformance @""
-#define kPsiphonWebTabLoadedNotification @"kPsiphonWebTabLoadedNotification"
+#define kPsiphonWebTabStartLoadNotification @"kPsiphonWebTabStartLoadNotification"
 
 #import "AppDelegate.h"
 #endif

--- a/Endless/PsiphonConnectionModalViewController.m
+++ b/Endless/PsiphonConnectionModalViewController.m
@@ -369,15 +369,15 @@
 		dismissOnViewDidAppear = NO;
 
 		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(psiphonWebTabLoaded)
-													 name:kPsiphonWebTabLoadedNotification object:nil];
+												 selector:@selector(psiphonWebTabStartLoad)
+													 name:kPsiphonWebTabStartLoadNotification object:nil];
 	}
 	return self;
 }
 
 -(void)dealloc {
 	[[NSNotificationCenter defaultCenter] removeObserver:self
-													name:kPsiphonWebTabLoadedNotification object:nil];
+													name:kPsiphonWebTabStartLoadNotification object:nil];
 }
 
 -(void) viewDidAppear:(BOOL)animated {
@@ -387,7 +387,7 @@
 	}
 }
 
-- (void) psiphonWebTabLoaded {
+- (void) psiphonWebTabStartLoad {
 	dismissOnViewDidAppear = YES;
 }
 

--- a/Endless/SettingsViewController.h
+++ b/Endless/SettingsViewController.h
@@ -37,6 +37,9 @@
 #define kUpstreamProxyHostAddress	@"upstreamProxyHostAddress"
 #define kUpstreamProxyPort			@"upstreamProxyPort"
 
+// disable Javascript settings key in Privacy.plist
+#define kDisableJavascript			@"disableJavascript"
+
 // These strings correspond to the option's value in MinTLSSettings.plist
 #define kMinTlsVersionTLS_1_2 @"TLS_1_2"
 #define kMinTlsVersionTLS_1_1 @"TLS_1_1"

--- a/Endless/SettingsViewController.m
+++ b/Endless/SettingsViewController.m
@@ -404,6 +404,7 @@ BOOL linksEnabled;
 	} else if  ([fieldName isEqual:appLanguage]) {
 		[[NSNotificationCenter defaultCenter] removeObserver:self];
 		appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
+		[self.webViewController settingsViewControllerDidEnd];
 		[appDelegate reloadAndOpenSettings];
 	}
 }

--- a/Endless/URLInterceptor.m
+++ b/Endless/URLInterceptor.m
@@ -379,7 +379,7 @@ static NSString *_javascriptToInject;
 	/* rewrite or inject Content-Security-Policy (and X-Webkit-CSP just in case) headers */
 	NSString *CSPheader = nil;
 
-	BOOL disableJavascript = [[NSUserDefaults standardUserDefaults] boolForKey:@"disableJavascript"];
+	BOOL disableJavascript = [[NSUserDefaults standardUserDefaults] boolForKey:kDisableJavascript];
 	if (disableJavascript) {
 		CSPheader = @"script-src 'none';";
 	}

--- a/Endless/WebViewTab.h
+++ b/Endless/WebViewTab.h
@@ -46,6 +46,7 @@ typedef NS_ENUM(NSInteger, WebViewTabSecureMode) {
 @property (strong, atomic) UIRefreshControl *refresher;
 @property (strong, atomic) NSURL *url;
 @property BOOL isRestoring;
+@property BOOL shouldReloadOnConnected;
 @property (strong, atomic) NSNumber *tabIndex;
 @property (strong, atomic) UIView *titleHolder;
 @property (strong, atomic) UILabel *title;

--- a/Endless/en.lproj/Localizable.strings
+++ b/Endless/en.lproj/Localizable.strings
@@ -231,9 +231,6 @@
 /* Text explaining thumbs up choice in feedback */
 "Psiphon connects\nand performs the\nway I want it to." = "Psiphon connects\nand performs the\nway I want it to.";
 
-/* Alert message that pops up when user is trying to navigate on the current webpage while Psiphon is not connected. */
-"Psiphon is not connected!" = "Psiphon is not connected!";
-
 /* Text explaining thumbs down choice in feedback */
 "Psiphon often fails\nto connect or\ndoesn't perform well\nenough." = "Psiphon often fails\nto connect or\ndoesn't perform well\nenough.";
 


### PR DESCRIPTION
Also, disable navigation from the page and flag tabs for reload upon 'connected' event if Psiphon is not currently connected.