### PR TITLE
WebViewController reload without leaking UIViews

### DIFF
--- a/Endless/AppDelegate.m
+++ b/Endless/AppDelegate.m
@@ -430,7 +430,6 @@
 
 	WebViewTab* focusedTab = [prevWebViewController curWebViewTab];
 
-
 	WebViewController* wvc = [[WebViewController alloc] init];
 	wvc.restorationIdentifier = @"WebViewController";
 	self.window.rootViewController = wvc;
@@ -448,12 +447,10 @@
 		[wvc addWebViewTab:wvt andSetCurrent:isCurrentTab];
 	}
 
-	// OK, some objects in the WebViewController leak, let's minimize the leakage
-	// footprint by trying and removing all subviews.
-	// TODO: runtime analysis of the leaks
-	[[prevWebViewController.view subviews] makeObjectsPerformSelector:@selector(removeFromSuperview)];
-
-	[prevWebViewController dismissViewControllerAnimated:NO completion:nil];
+	[prevWebViewController dismissViewControllerAnimated:NO completion:^{
+		// Remove the root view in case it is still showing
+		 [prevWebViewController.view removeFromSuperview];
+	}];
 
 	[self notifyPsiphonConnectionState];
 	[self.webViewController setOpenSettingImmediatelyOnViewDidAppear:YES];

--- a/Endless/WebViewController.m
+++ b/Endless/WebViewController.m
@@ -1849,16 +1849,19 @@
 																		   initWithState:[[AppDelegate sharedAppDelegate] psiphonConectionState]];
 	connectionAlertViewController.delegate = self;
 
+	__weak  WebViewController *weakSelf = self;
+	__weak  PsiphonConnectionAlertViewController *weakConnectionAlertViewController = connectionAlertViewController;
+
 	[connectionAlertViewController addAction:[NYAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil)
 																	  style:UIAlertActionStyleDefault
 																	handler:^(NYAlertAction *action) {
-																		[self openSettingsMenu:nil];
+																		[weakSelf openSettingsMenu:nil];
 																	}]];
 
 	[connectionAlertViewController addAction:[NYAlertAction actionWithTitle:NSLocalizedString(@"Done", nil)
 																	  style:UIAlertActionStyleDefault
 																	handler:^(NYAlertAction *action) {
-																		[connectionAlertViewController.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+																		[weakConnectionAlertViewController.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 																	}]];
 
 	[self  presentViewController:connectionAlertViewController animated:NO


### PR DESCRIPTION
No more hanging UIViews in the Allocations are seen when root view controller is reloaded.