### PR TITLE
Swipe up to remove tab, move tab chooser to the bottom

### DIFF
--- a/Endless/WebViewController.h
+++ b/Endless/WebViewController.h
@@ -12,6 +12,10 @@
 
 #import "Tutorial.h"
 
+#define PAN_GESTURE_RECOGNIZER_NONE 0
+#define PAN_GESTURE_RECOGNIZER_UP 1
+#define PAN_GESTURE_RECOGNIZER_SIDE 2
+
 /* Psiphon tutorial steps */
 typedef NS_ENUM(NSInteger, PsiphonTutorialStep)
 {

--- a/Endless/WebViewController.m
+++ b/Endless/WebViewController.m
@@ -442,6 +442,9 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
+	// reset gesture recognizer type
+	panGestureRecognizerType = PAN_GESTURE_RECOGNIZER_NONE;
+
 	[super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 
 	[coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {

--- a/Endless/WebViewController.m
+++ b/Endless/WebViewController.m
@@ -1966,6 +1966,17 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 					break;
 				};
 
+				case UIGestureRecognizerStateCancelled: {
+					CGRect frame = tabScroller.frame;
+					frame.origin.x = frame.size.width * curTabIndex;
+					frame.origin.y = 0;
+					[tabScroller setContentOffset:frame.origin animated:YES];
+
+					panGestureRecognizerType = PAN_GESTURE_RECOGNIZER_NONE;
+
+					break;
+				}
+
 				default: break;
 			}
 
@@ -2001,6 +2012,17 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 
 					break;
 				};
+
+				case UIGestureRecognizerStateCancelled: {
+					// Move the view back to the original point
+					[UIView animateWithDuration:0.5 animations:^{
+						[tabView setCenter:originalPoint];
+					} completion:^(BOOL finished) {}];
+					panGestureRecognizerType = PAN_GESTURE_RECOGNIZER_NONE;
+
+					break;
+				}
+
 
 				default: break;
 			}


### PR DESCRIPTION
...and make it switch pages

Mostly copied from Endless fork by JRock007

Tab swipe:
https://github.com/JRock007/endless/commit/70c5519872cf2ef9be94e076080c09878c63ebde

Tab chooser switch pages when page control dots are clicked:
https://github.com/JRock007/endless/commit/a190ade5a10078ba072f598b54e63af9bd2d21dd