### PR TITLE
Time based home pages opening

### DIFF
--- a/Endless/AppDelegate.h
+++ b/Endless/AppDelegate.h
@@ -36,6 +36,10 @@
 #define kHasBeenOnboardedKey @"hasBeenOnBoarded"
 #define kBuildNumber @"buildNumber"
 
+#define APP_ACTIVE_TIMER_INTERVAL_SECONDS 60 * 5 // store elapsed time every 5 minutes
+#define APP_ACTIVE_TIME_BEFORE_NEXT_HOMEPAGE_SECONDS 60 * 60 * 2 // do not open more home pages if app has been active less than 2 hours since last home page
+#define kAppActiveTimeSinceLastHomePage @"appActiveTimeSinceLastHomePage"
+
 @interface AppDelegate : UIResponder <UIApplicationDelegate, TunneledAppDelegate, JAHPAuthenticatingHTTPProtocolDelegate, OnboardingViewControllerDelegate>
 
 @property (strong, nonatomic) UIWindow *window;

--- a/Endless/AppDelegate.h
+++ b/Endless/AppDelegate.h
@@ -37,7 +37,7 @@
 #define kBuildNumber @"buildNumber"
 
 #define APP_ACTIVE_TIMER_INTERVAL_SECONDS 60 * 5 // store elapsed time every 5 minutes
-#define APP_ACTIVE_TIME_BEFORE_NEXT_HOMEPAGE_SECONDS 60 * 60 * 2 // do not open more home pages if app has been active less than 2 hours since last home page
+#define APP_ACTIVE_TIME_BEFORE_NEXT_HOMEPAGE_SECONDS 60 * 30 // do not open more home pages if app has been active less than 30 minutes since last home page
 #define kAppActiveTimeSinceLastHomePage @"appActiveTimeSinceLastHomePage"
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate, TunneledAppDelegate, JAHPAuthenticatingHTTPProtocolDelegate, OnboardingViewControllerDelegate>

--- a/Endless/AppDelegate.m
+++ b/Endless/AppDelegate.m
@@ -226,7 +226,7 @@
 
 - (void) startAppActiveTimer {
 	if (!_appActiveTimer || ![_appActiveTimer isValid]) {
-		_lastActiveTickTime = CACurrentMediaTime();
+		_lastActiveTickTime = (long)CACurrentMediaTime();
 		_appActiveTimer = [NSTimer scheduledTimerWithTimeInterval:APP_ACTIVE_TIMER_INTERVAL_SECONDS
 														   target:self
 														 selector:@selector(onAppActiveTimerTick:)
@@ -389,9 +389,22 @@
 
 - (void)onAppActiveTimerTick:(NSTimer *)timer {
 	long elapsedInterval = (long)CACurrentMediaTime() - _lastActiveTickTime;
+	if(elapsedInterval > 0) {
+		long currentAppActiveTime = [[NSUserDefaults standardUserDefaults] integerForKey:kAppActiveTimeSinceLastHomePage];
+		if(currentAppActiveTime < 0) {
+			// Guard against defaults corruption.
+			// We care less if the number is too large, worst case we will prematurely
+			// open a home page on the next reconnect.
+			currentAppActiveTime = 0;
+		}
+		long newAppActiveTime;
 
-	long currentAppActiveTime = [[NSUserDefaults standardUserDefaults] integerForKey:kAppActiveTimeSinceLastHomePage];
-	[[NSUserDefaults standardUserDefaults] setInteger:(currentAppActiveTime + elapsedInterval) forKey:kAppActiveTimeSinceLastHomePage];
+		if(!__builtin_saddl_overflow(currentAppActiveTime, elapsedInterval, &newAppActiveTime)){
+			// no overlow, write new value to defaults
+			[[NSUserDefaults standardUserDefaults] setInteger:(newAppActiveTime) forKey:kAppActiveTimeSinceLastHomePage];
+		}
+		// do nothing in case of overflow
+	}
 
 	_lastActiveTickTime = (long)CACurrentMediaTime();
 }
@@ -508,7 +521,7 @@
 			AudioServicesPlaySystemSound (_notificationSound);
 		}
 
-		// If kAppActiveTimeSinceLastHomePage doesn't exist then it is probably is the very first app run
+		// If kAppActiveTimeSinceLastHomePage doesn't exist then it is probably the very first app run
 		// and we should show a home page
 		BOOL shouldOpenHomePage = ([[NSUserDefaults standardUserDefaults] objectForKey:kAppActiveTimeSinceLastHomePage] == nil);
 		NSLog(@"shouldOpenHomePage == %@ , kAppActiveTimeSinceLastHomePage exists == %@", shouldOpenHomePage ? @"YES" : @"NO", !shouldOpenHomePage ? @"YES" : @"NO");
@@ -517,7 +530,10 @@
 		if(!shouldOpenHomePage) {
 			// Check if enough uptime has passed and we should show a home page
 			long activeTime = [[NSUserDefaults standardUserDefaults] integerForKey:kAppActiveTimeSinceLastHomePage];
-			shouldOpenHomePage = (activeTime > APP_ACTIVE_TIME_BEFORE_NEXT_HOMEPAGE_SECONDS);
+
+			// If activeTime is negative then defaults are probably corrupted
+			// Fix it by showing a home page which will also reset the corrupted value to 0
+			shouldOpenHomePage = (activeTime < 0 || activeTime > APP_ACTIVE_TIME_BEFORE_NEXT_HOMEPAGE_SECONDS);
 #ifdef TRACE
 			NSLog(@"shouldOpenHomePage == %@, App active time == %ld, APP_ACTIVE_TIME_BEFORE_NEXT_HOMEPAGE_SECONDS == %d", shouldOpenHomePage ? @"YES" : @"NO", activeTime, APP_ACTIVE_TIME_BEFORE_NEXT_HOMEPAGE_SECONDS);
 #endif
@@ -549,12 +565,14 @@
 				// Otherwise it should be started when the app becomes active
 				// in the - (void)applicationDidBecomeActive:(UIApplication *)application
 				BOOL shouldStartTimer = ([[NSUserDefaults standardUserDefaults] objectForKey:kAppActiveTimeSinceLastHomePage] == nil);
+
+				// Reset active time since last home page once we open a homepage
+				// That will also create kAppActiveTimeSinceLastHomePage if it didn't exist
+				[[NSUserDefaults standardUserDefaults] setInteger:0 forKey:kAppActiveTimeSinceLastHomePage];
+
 				if(shouldStartTimer) {
 					[self startAppActiveTimer];
 				}
-
-				// Also reset active time since last home page once we open a homepage
-				[[NSUserDefaults standardUserDefaults] setInteger:0 forKey:kAppActiveTimeSinceLastHomePage];
 			}
 		}
 	});

--- a/Endless/ICDMaterialActivityIndicatorView.m
+++ b/Endless/ICDMaterialActivityIndicatorView.m
@@ -105,11 +105,11 @@
 
 	switch (style) {
 		case ICDMaterialActivityIndicatorViewStyleSmall:
-			self.lineWidth = 2.0;
+			self.lineWidth = 1.0;
 			self.duration = 0.8;
 			break;
 		case ICDMaterialActivityIndicatorViewStyleMedium:
-			self.lineWidth = 4.0;
+			self.lineWidth = 3.0;
 			self.duration = 0.8;
 			break;
 		case ICDMaterialActivityIndicatorViewStyleLarge:

--- a/Endless/PsiphonConnectionIndicator.m
+++ b/Endless/PsiphonConnectionIndicator.m
@@ -18,11 +18,12 @@
  */
 
 #import "PsiphonConnectionIndicator.h"
+#import "ICDMaterialActivityIndicatorView.h"
 
 @implementation PsiphonConnectionIndicator {
 	UIImageView *_imgConnected;
 	UIImageView *_imgDisconnected;
-	UIActivityIndicatorView *_activityIndicator;
+	ICDMaterialActivityIndicatorView *_activityIndicator;
 }
 
 - (id) initWithFrame:(CGRect)frame {
@@ -35,8 +36,8 @@
 	_imgDisconnected.alpha = 0.0;
 	[self addSubview:_imgDisconnected];
 
-	_activityIndicator = [[UIActivityIndicatorView alloc]
-						  initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+	_activityIndicator = [[ICDMaterialActivityIndicatorView alloc]
+						  initWithActivityIndicatorStyle:ICDMaterialActivityIndicatorViewStyleMedium];
 	_activityIndicator.alpha = 0.0;
 	[self addSubview:_activityIndicator];
 
@@ -47,7 +48,6 @@
 	// The tiny circle on the bottom right sticks out about 1/11 of the image width
 	float offset = (_imgDisconnected.frame.size.width / 11.0)/2;
 	_activityIndicator.center = CGPointMake(self.bounds.size.width / 2 - offset, self.bounds.size.height/2 - offset);
-
 
 	[self displayConnectionState:PsiphonConnectionStateDisconnected];
 	return self;

--- a/Endless/WebViewController.h
+++ b/Endless/WebViewController.h
@@ -49,14 +49,13 @@ typedef NS_ENUM(NSInteger, PsiphonTutorialStep)
 - (void)forceRefresh;
 - (void)prepareForNewURLFromString:(NSString *)url;
 
-
 - (void) stopLoading;
 
 - (void) overlayTutorial;
 - (void) focusTab:(WebViewTab *)tab andRefresh:(BOOL)refresh animated:(BOOL)animated;
 - (void) openPsiphonHomePage:(NSString *) homePage;
 - (void) showPsiphonConnectionStatusAlert;
-
+- (void) setRestorationTabCurrent;
 
 @property (nonatomic) BOOL showTutorial;
 @property (nonatomic) BOOL resumePsiphonStart;


### PR DESCRIPTION
Home pages open when Psiphon gets connected in two cases:
1. There are no tabs open or
2. The app had been foregrounded for a total of ~~two hours~~ 30 minutes
since the last home page opening

Also:
* A bug fixed for restoration tab not being refreshed when it is switched to
* Logo connection spinner  matches that in the status connection modal