### PR TITLE
Minor fixes

### DIFF
--- a/Endless/FeedbackViewController.m
+++ b/Endless/FeedbackViewController.m
@@ -27,12 +27,12 @@
 
 #define kCommentsFrameHeight 44*3
 
-#define kCommentsSpecifierKey        @"comments"
-#define kEmailSpecifierKey           @"email"
-#define kFooterTextSpecifierKey      @"footerText"
-#define kIntroTextSpecifierKey       @"introText"
-#define kSendDiagnosticsSpecifierKey @"sendDiagnostics"
-#define kThumbsSpecifierKey          @"thumbs"
+#define kCommentsSpecifierKey			@"comments"
+#define kEmailSpecifierKey				@"email"
+#define kFooterTextSpecifierKey			@"footerText"
+#define kIntroTextSpecifierKey			@"introText"
+#define kSendDiagnosticsSpecifierKey	@"sendDiagnostics"
+#define kThumbsSpecifierKey				@"thumbs"
 
 @implementation FeedbackViewController {
 	FeedbackThumbsCell *_thumbsCell;
@@ -62,8 +62,8 @@
 																			 action:@selector(sendFeedback:)];
 	self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Cancel", "Text of button to discard feedback and return to main settings menu")
 																			 style:UIBarButtonItemStyleDone
-																			target:self.navigationController
-																			action:@selector(dismissModalViewControllerAnimated:)];
+																			target:self
+																			action:@selector(dismiss:)];
 
 	// UISegmentedControl content initialization
 	_thumbsCell = [[FeedbackThumbsCell alloc] init];
@@ -107,7 +107,7 @@
 							 sendDiagnosticInfo:uploadDiagnostics
 							  withPsiphonConfig:psiphonConfig];
 	});
-	[self dismissViewControllerAnimated:YES completion:nil];
+	[self.navigationController popViewControllerAnimated:YES];
 }
 
 #pragma mark - IASK UITableView delegate methods
@@ -278,14 +278,10 @@
 	if ([[URL scheme] containsString:@"mailto"]) { // User has clicked feedback email address
 		return YES;
 	}
-	UIViewController *wvc = [[UIViewController alloc] init];
-	UIWebView *wv = [[UIWebView alloc] initWithFrame:self.navigationController.view.bounds];
-	wv.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
 
-	[wv loadRequest:[NSURLRequest requestWithURL:URL]];
-	[wvc.view addSubview:wv];
-
-	[self.navigationController pushViewController:wvc animated:YES];
+	[[AppDelegate sharedAppDelegate].webViewController addNewTabForURL:URL];
+	[[AppDelegate sharedAppDelegate].webViewController settingsWillDismissWithForceReconnect:NO];
+	[self.navigationController dismissViewControllerAnimated:YES completion:nil];
 	return NO;
 }
 
@@ -344,7 +340,13 @@
 
 - (void)settingsViewControllerDidEnd:(IASKAppSettingsViewController *)sender
 {
-	[self dismissViewControllerAnimated:YES completion:nil];
+	[self.navigationController popViewControllerAnimated:YES];
+}
+
+#pragma mark - Helper functions
+
+- (void)dismiss:(id)sender {
+	[self.navigationController popViewControllerAnimated:YES];
 }
 
 @end

--- a/Endless/SettingsViewController.m
+++ b/Endless/SettingsViewController.m
@@ -196,8 +196,7 @@ BOOL linksEnabled;
 
 		IASK_IF_IOS7_OR_GREATER(targetViewController.view.tintColor = self.view.tintColor;)
 
-		UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:targetViewController];
-		[self presentViewController:navController animated:YES completion:nil];
+		[self.navigationController pushViewController:targetViewController animated:YES];
 	} else if ([specifier.key isEqualToString:kHttpsEverywhereSpecifierKey]) {
 		[self menuHTTPSEverywhere];
 	} else if ([specifier.key isEqualToString:kUpstreamProxyPort] || [specifier.key isEqualToString:kUpstreamProxyHostAddress]) {

--- a/Endless/WebViewController.m
+++ b/Endless/WebViewController.m
@@ -278,8 +278,7 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 	[self.view insertSubview:tabToolbar aboveSubview:navigationBar];
 
 	tabAddButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd target:self action:@selector(addNewTabFromToolbar:)];
-	tabDoneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneWithTabsButton:)];
-	tabDoneButton.title = NSLocalizedString(@"Done", @"Done button title, dismisses the tab chooser");
+	tabDoneButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Done", @"Done button title, dismisses the tab chooser") style:UIBarButtonItemStyleDone target:self action:@selector(doneWithTabsButton:)];
 
 	tabToolbar.items = [NSArray arrayWithObjects:
 						[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:self action:nil],

--- a/Endless/WebViewController.m
+++ b/Endless/WebViewController.m
@@ -172,8 +172,6 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 
 	psiphonConnectionIndicator = [[PsiphonConnectionIndicator alloc]
 								  initWithFrame: [self frameForConnectionIndicator]];
-	[psiphonConnectionIndicator addTarget:self action:@selector(showPsiphonConnectionStatusAlert)
-						 forControlEvents:UIControlEventTouchUpInside];
 
 	[navigationBar addSubview:psiphonConnectionIndicator];
 
@@ -181,19 +179,16 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 	[lockIcon setFrame:CGRectMake(0, 0, 24, 16)];
 	[lockIcon setImage:[UIImage imageNamed:@"lock"] forState:UIControlStateNormal];
 	[[lockIcon imageView] setContentMode:UIViewContentModeScaleAspectFit];
-	[lockIcon addTarget:self action:@selector(showSSLCertificate) forControlEvents:UIControlEventTouchUpInside];
 
 	brokenLockIcon = [UIButton buttonWithType:UIButtonTypeCustom];
 	[brokenLockIcon setFrame:CGRectMake(0, 0, 24, 16)];
 	[brokenLockIcon setImage:[UIImage imageNamed:@"broken_lock"] forState:UIControlStateNormal];
 	[[brokenLockIcon imageView] setContentMode:UIViewContentModeScaleAspectFit];
-	[brokenLockIcon addTarget:self action:@selector(showSSLCertificate) forControlEvents:UIControlEventTouchUpInside];
 
 	refreshButton = [UIButton buttonWithType:UIButtonTypeCustom];
 	[refreshButton setFrame:CGRectMake(0, 0, 24, 16)];
 	[refreshButton setImage:[UIImage imageNamed:@"refresh"] forState:UIControlStateNormal];
 	[[refreshButton imageView] setContentMode:UIViewContentModeScaleAspectFit];
-	[refreshButton addTarget:self action:@selector(forceRefresh) forControlEvents:UIControlEventTouchUpInside];
 
 	backButton = [UIButton buttonWithType:UIButtonTypeCustom];
 	UIImage *backImage = [[UIImage imageNamed: isRTL ? @"arrow_right" : @"arrow_left"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
@@ -1489,8 +1484,12 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 		refreshTarget = CGRectMake(isRTL ? 0 : refreshFrame.origin.x - 15, 0, isRTL ? refreshFrame.origin.x + refreshFrame.size.width + 15 : navigationBar.frame.size.width - refreshFrame.origin.x + 15, navigationBar.frame.size.height);
 	}
 
-	CGRect urlFieldTarget = CGRectMake(urlField.frame.origin.x, 0, navigationBar.frame.size.width - urlField.frame.origin.x, navigationBar.frame.size.height);
+	CGRect urlFieldFrame = [navigationBar convertRect:urlField.frame toView:navigationBar];
+	CGRect urlFieldTarget = CGRectMake(urlFieldFrame.origin.x, 0, urlFieldFrame.size.width, navigationBar.frame.size.height);
 
+	// Do not add target/actions for touch events to views fuzzed
+	// this way. This prevents triggering an action twice if the
+	// view is pressed within its frame.
 	if (CGRectContainsPoint(connectionIndicatorTarget, point)) {
 		[self showPsiphonConnectionStatusAlert];
 	} else if (CGRectContainsPoint(lockTarget, point)) {


### PR DESCRIPTION
- Done button on all-tabs view was not localized
- FAQ and Privacy Policy links in FeedbackViewController would push a UIWebView on press. Now settings view is dismissed and a new tab is opened in the main browser.
- Presses triggering nav bar target/actions twice caused memory leaks on presented view controllers (SSLCertificateViewController, PsiphonConnectionAlertViewController)