### PR TITLE
Fix: underflow when checking length of empty array led to crash

### DIFF
--- a/Endless/SSLCertificate.m
+++ b/Endless/SSLCertificate.m
@@ -234,7 +234,12 @@
 		return nil;
 	}
 
-	if (index > ([arr count] - 1)) {
+	if (index < 0) {
+		NSLog(@"[SSLCertificate] invalid index %ld, index must be a non-negative integer", (long)index);
+		return nil;
+	}
+
+	if (index > [arr count]) {
 		NSLog(@"[SSLCertificate] array count is %lu, need index %lu", (unsigned long)[arr count], (long)index);
 		return nil;
 	}


### PR DESCRIPTION
 In safeFetchFromArray:
```
if (index > ([arr count] - 1)) {
		NSLog(@"[SSLCertificate] array count is %lu, need index %lu", (unsigned long)[arr count], (long)index);
		return nil;
}

NSObject *ret = [arr objectAtIndex:index]; // crashes
```
The count property of NSArray is an unsigned integer, thus `[arr count]-1` results in an underflow which leads to accessing an invalid index in the array.