### PR TITLE
Fix: allow users to use camera app to capture and upload media.

### DIFF
--- a/Endless/Info.plist
+++ b/Endless/Info.plist
@@ -41,8 +41,12 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>This lets you take and upload pictures.</string>
 	<key>NSMainNibFile</key>
 	<string>Launch Screen</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This lets you record and upload audio.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This lets you save and upload photos.</string>
 	<key>UIAppFonts</key>


### PR DESCRIPTION
Fixes crash on missing usage description in plist

i.e. `
This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSCameraUsageDescription key with a string value explaining to the user how the app uses this data.
`