### PR TITLE
Do not translate 'Psiphon'

### DIFF
--- a/Endless/InAppSettings.bundle/Privacy.plist
+++ b/Endless/InAppSettings.bundle/Privacy.plist
@@ -38,7 +38,7 @@
 			<key>FooterTextDefault</key>
 			<string>Manage what types of cookies Psiphon Browser allows.</string>
 			<key>FooterTextDescription</key>
-			<string>Explanatory text for the "Allow Cookies" setting.</string>
+			<string>Explanatory text for the "Allow Cookies" setting. DO NOT translate 'Psiphon'.</string>
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
@@ -135,7 +135,7 @@
 			<key>FooterTextDefault</key>
 			<string>Websites may store cookies and other data on your device to identify you when browsing. This data is usually used to provide services and content specific to you. It can include your login information, preferences, and personal information such as your name or email address. Psiphon Browser blocks cookies from sites other than the one you are visiting (third party cookies) by default to help prevent advertisers from storing data on your device.</string>
 			<key>FooterTextDescription</key>
-			<string>Explanatory text on the "Allow Cookies" setting options page.</string>
+			<string>Explanatory text on the "Allow Cookies" setting options page. DO NOT translate 'Psiphon'.</string>
 		</dict>
 		<dict>
 			<key>Type</key>

--- a/Endless/InAppSettings.bundle/Root.inApp.plist
+++ b/Endless/InAppSettings.bundle/Root.inApp.plist
@@ -10,7 +10,7 @@
 			<key>TitleDefault</key>
 			<string>Psiphon Browser</string>
 			<key>TitleDescription</key>
-			<string>Settings view subheading for Psiphon-specific settings.</string>
+			<string>Settings view subheading for Psiphon-specific settings. DO NOT translate 'Psiphon'.</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>

--- a/Endless/OnboardingInfoViewController.m
+++ b/Endless/OnboardingInfoViewController.m
@@ -245,7 +245,7 @@
 		}
 		case PsiphonOnboardingPage2Index: {
 			titleView.text = NSLocalizedStringWithDefaultValue(@"ONBOARDING_APPS_TITLE", nil, [NSBundle mainBundle], @"Your Apps in Your Browser", @"Title text on one of the on-boarding screens. The intention of this screen is to let the user know that their sites and services -- Facebook, Twitter, etc. -- can be accessed within Psiphon Browser via web pages.");
-			textView.text =  NSLocalizedStringWithDefaultValue(@"ONBOARDING_APPS_TEXT", nil, [NSBundle mainBundle], @"Your favorite apps have a web interface that works great in Psiphon Browser", @"Body text on one of the on-boarding screens. The intention of this screen is to let the user know that their sites and services -- Facebook, Twitter, etc. -- can be accessed within Psiphon Browser via web pages.");
+			textView.text =  NSLocalizedStringWithDefaultValue(@"ONBOARDING_APPS_TEXT", nil, [NSBundle mainBundle], @"Your favorite apps have a web interface that works great in Psiphon Browser", @"Body text on one of the on-boarding screens. The intention of this screen is to let the user know that their sites and services -- Facebook, Twitter, etc. -- can be accessed within Psiphon Browser via web pages. DO NOT translate 'Psiphon'.");
 			break;
 		}
 		case PsiphonOnboardingPage3Index: {

--- a/Endless/OnboardingViewController.m
+++ b/Endless/OnboardingViewController.m
@@ -219,7 +219,7 @@
 	title.font = [UIFont fontWithName:@"Bourbon-Oblique" size:self.view.frame.size.width * 0.10625f];
 	title.textColor = [UIColor whiteColor];
 	title.textAlignment = NSTextAlignmentCenter;
-	title.text = NSLocalizedStringWithDefaultValue(@"ONBOARDING_APP_NAME", nil, [NSBundle mainBundle], @"PSIPHON BROWSER", @"Title displayed at top of all onboarding screens. This should be in all-caps if that makes sense in your language.");
+	title.text = NSLocalizedStringWithDefaultValue(@"ONBOARDING_APP_NAME", nil, [NSBundle mainBundle], @"PSIPHON BROWSER", @"Title displayed at top of all onboarding screens. This should be in all-caps if that makes sense in your language. DO NOT translate 'Psiphon'.");
 	if ([PsiphonClientCommonLibraryHelpers unsupportedCharactersForFont:title.font.fontName withString:title.text]) {
 		title.font = [UIFont systemFontOfSize:self.view.frame.size.width * 0.075f];
 	}

--- a/Endless/PsiphonConnectionModalViewController.m
+++ b/Endless/PsiphonConnectionModalViewController.m
@@ -323,7 +323,7 @@
 								  @"Connection status initial splash modal dialog title for 'Psiphon can not start due to an internal error' state");
 		message = NSLocalizedStringWithDefaultValue(@"CONNECTION_STATUS_ERROR_MESSAGE", nil, [NSBundle mainBundle], 
 									@"Psiphon can not start due to an internal error, please send feedback.",
-									@"Connection status initial splash modal dialog message for 'Psiphon can not start due to an internal error' state");
+									@"Connection status initial splash modal dialog message for 'Psiphon can not start due to an internal error' state. DO NOT translate 'Psiphon'.");
 		// TODO: display 'can't start' icon in the contentView
 		contentView = [[UIView alloc] initWithFrame:CGRectZero];
 	}

--- a/Endless/TutorialPageViewController.m
+++ b/Endless/TutorialPageViewController.m
@@ -306,13 +306,13 @@
 	NSAttributedString *attrStringWithImage = [NSAttributedString attributedStringWithAttachment:textAttachment];
 	[attributedString appendAttributedString:attrStringWithImage];
 	[attributedString appendAttributedString:[[NSAttributedString alloc] initWithString:@" "]];
-	[attributedString appendAttributedString:[[NSAttributedString alloc] initWithString:NSLocalizedStringWithDefaultValue(@"TUTORIAL_BODY_STATUS", nil, [NSBundle mainBundle], @"The green checkmark indicates that Psiphon Browser is connected and ready for you to start browsing", @"Text on first tutorial screen which highlights the connection indicator")]];
+	[attributedString appendAttributedString:[[NSAttributedString alloc] initWithString:NSLocalizedStringWithDefaultValue(@"TUTORIAL_BODY_STATUS", nil, [NSBundle mainBundle], @"The green checkmark indicates that Psiphon Browser is connected and ready for you to start browsing", @"Text on first tutorial screen which highlights the connection indicator. DO NOT translate 'Psiphon'.")]];
 
 	NSArray<NSAttributedString*>* bodyText = @[
 											   [[NSAttributedString alloc] initWithString:@""],
 											   attributedString,
 											   [[NSAttributedString alloc] initWithString:NSLocalizedStringWithDefaultValue(@"TUTORIAL_BODY_SETTINGS", nil, [NSBundle mainBundle], @"This is where you can access settings and find help", @"Text on second tutorial screen which highlights the settings button")],
-											   [[NSAttributedString alloc] initWithString:NSLocalizedStringWithDefaultValue(@"TUTORIAL_BODY_FINAL", nil, [NSBundle mainBundle], @"Now we'll connect to a Psiphon server so you can start browsing.", @"Text on last tutorial screen which prompts the user to exit tutorial and start browsing with Psiphon Browser")]
+											   [[NSAttributedString alloc] initWithString:NSLocalizedStringWithDefaultValue(@"TUTORIAL_BODY_FINAL", nil, [NSBundle mainBundle], @"Now we'll connect to a Psiphon server so you can start browsing.", @"Text on last tutorial screen which prompts the user to exit tutorial and start browsing with Psiphon Browser. DO NOT translate 'Psiphon'.")]
 											   ];
 
 	if (self.index < bodyText.count) {

--- a/Endless/WebViewTab.m
+++ b/Endless/WebViewTab.m
@@ -888,7 +888,7 @@
 					// changes privacy settings in the settings menu.
 					// It will be automatically relaunched when the user
 					// navigates back.
-					NSString *accessDescription = NSLocalizedStringWithDefaultValue(@"PHOTO_LIBRARY_ACCESS_PROMPT", nil, [NSBundle mainBundle], @"\"Psiphon Browser\" needs access to your photo library to save and upload images", @"Alert text telling user additional permissions must be granted to save and upload photos in the browser");
+					NSString *accessDescription = NSLocalizedStringWithDefaultValue(@"PHOTO_LIBRARY_ACCESS_PROMPT", nil, [NSBundle mainBundle], @"\"Psiphon Browser\" needs access to your photo library to save and upload images", @"Alert text telling user additional permissions must be granted to save and upload photos in the browser. DO NOT translate 'Psiphon'.");
 					UIAlertController *alertController = [UIAlertController alertControllerWithTitle:accessDescription message:NSLocalizedStringWithDefaultValue(@"PHOTO_LIBRARY_ACCESS_INSTRUCTION", nil, [NSBundle mainBundle], @"To give permissions tap on 'Change Settings' button", @"Alert text telling user which button to press if they want to be redirected to the settings menu") preferredStyle:UIAlertControllerStyleAlert];
 
 					UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedStringWithDefaultValue(@"CANCEL_ACTION", nil, [NSBundle mainBundle], @"Cancel", @"Cancel action") style:UIAlertActionStyleCancel handler:nil];

--- a/Endless/en.lproj/Localizable.strings
+++ b/Endless/en.lproj/Localizable.strings
@@ -1,8 +1,5 @@
 /* THIS FILE IS GENERATED. DO NOT EDIT. */
 
-/* External link to the about page. Please update this with the correct language specific link (if available) e.g. https://psiphon.ca/fr/about.html for french. */
-"ABOUT_PAGE_URL" = "https://psiphon.ca/en/about.html";
-
 /* 'Add bookmark' dialog title */
 "ADD_BOOKMARK_TITLE" = "Add Bookmark";
 
@@ -130,14 +127,13 @@
 /* Connection status initial splash modal dialog title for 'Psiphon can not start due to an internal error' state */
 "CONNECTION_STATUS_DISCONNECTED" = "Disconnected!";
 
-/* Connection status initial splash modal dialog message for 'Psiphon can not start due to an internal error' state */
+/* Connection status initial splash modal dialog message for 'Psiphon can not start due to an internal error' state. DO NOT translate 'Psiphon'. */
 "CONNECTION_STATUS_ERROR_MESSAGE" = "Psiphon can not start due to an internal error, please send feedback.";
 
 /* Connection status initial splash modal dialog title for 'Waiting for network...' state */
 "CONNECTION_STATUS_WAITING" = "Waiting for network...";
 
-/* Done action
-   Title of the button that dismisses the settings menu (InAppSettingsKit) */
+/* Done action */
 "DONE_ACTION" = "Done";
 
 /* Text of button on download preview screen which allows users to see what other actions they can perform with the file */
@@ -151,39 +147,6 @@
 
 /* Edit Bookmark dialog title */
 "EDIT_BOOKMARK_TITLE" = "Edit Bookmark";
-
-/* FAQ link text */
-"FAQ_LINK_TEXT" = "Frequently Asked Questions";
-
-/* External link to the FAQ page. Please update this with the correct language specific link (if available) e.g. https://psiphon.ca/fr/faq.html for french. */
-"FAQ_URL" = "https://psiphon.ca/en/faq.html";
-
-/* Comments section placeholder text */
-"FEEDBACK_COMMENTS_PLACEHOLDER" = "What's on your mind? Please leave us your feedback";
-
-/* Text referring user to frequently asked questions. %@ is where the separate translation for the phrase 'Frequently Asked Questions' will be placed. */
-"FEEDBACK_FAQ_DIRECTION" = "You can find solutions to many common problems in our %@.";
-
-/* Feedback footer text referring users to privacy policy. %@ is where the separate translation for the phrase 'Privacy Policy' will be placed. */
-"FEEDBACK_FOOTER_DATA_COLLECTION" = "Learn more about the data we collect in our %@";
-
-/* Feedback footer text. */
-"FEEDBACK_FOOTER_DIAGNOSTIC" = "Please note that this diagnostic data does not identify you, and it helps us keep Psiphon running smoothly.";
-
-/* Feedback footer text referring users to feedback email. %@ is where the separate translation for the email will be placed. */
-"FEEDBACK_FOOTER_EMAIL" = "If the above form is not working or you would like to send screenshots, please email us at %@";
-
-/* Introduction text at top of feedback form */
-"FEEDBACK_INTRODUCTION" = "Your feedback makes Psiphon better!";
-
-/* Text of button to send feedback */
-"FEEDBACK_SEND_BUTTON" = "Send";
-
-/* Text explaining thumbs down choice in feedback */
-"FEEDBACK_THUMBS_DOWN_TEXT" = "Psiphon often fails\nto connect or\ndoesn't perform well\nenough.";
-
-/* Text explaining thumbs up choice in feedback */
-"FEEDBACK_THUMBS_UP_TEXT" = "Psiphon connects\nand performs the\nway I want it to.";
 
 /* HTTP authentication alert log in button action */
 "HTTP_AUTH_LOG_IN" = "Log In";
@@ -231,9 +194,6 @@
    Title above language box which displays the current app language and all available languages that the app is localized for */
 "LANGUAGE_SELECT_TITLE" = "Language";
 
-/* External link to the license page. Please update this with the correct language specific link (if available) e.g. https://psiphon.ca/fr/license.html for french. */
-"LICENSE_PAGE_URL" = "https://psiphon.ca/en/license.html";
-
 /* Action title for long press on link dialog */
 "LINK_LONG_PRESS_COPY_URL" = "Copy URL";
 
@@ -245,15 +205,6 @@
 
 /* Action title for long press on link dialog */
 "LINK_LONG_PRESS_OPEN_SAFARI" = "Open in Safari";
-
-/* Title of screen that displays logs */
-"LOGS_TITLE" = "Logs";
-
-/* Shown when the device is not configured for sending email. (InAppSettingsKit) */
-"MAIL_NOT_CONFIGURED" = "Mail not configured";
-
-/* Description for the 'Mail not configured' message. (InAppSettingsKit) */
-"MAIL_NOT_CONFIGURED_DESC" = "This device is not configured for sending Email. Please configure the Mail settings in the Settings app.";
 
 /* New browser tab title text */
 "NEW_TAB_TITLE" = "New Tab";
@@ -267,22 +218,19 @@
 /* OK action */
 "OK_ACTION" = "OK";
 
-/* Alert OK Button. (InAppSettingsKit) */
-"OK_BUTTON" = "OK";
-
 /* Body text on one of the on-boarding screens. It is indicating to the user that Psiphon Browser allows them to access the Internet (without censorship). */
 "ONBOARDING_ACCESS_TEXT" = "The Internet at your fingertips";
 
 /* Title text on one of the on-boarding screens */
 "ONBOARDING_ACCESS_TITLE" = "Access the Web";
 
-/* Title displayed at top of all onboarding screens. This should be in all-caps if that makes sense in your language. */
+/* Title displayed at top of all onboarding screens. This should be in all-caps if that makes sense in your language. DO NOT translate 'Psiphon'. */
 "ONBOARDING_APP_NAME" = "PSIPHON BROWSER";
 
 /* Title displayed at the top of all onboardings screens. This should be in all-caps if that makes sense in your language. This is a slogan and should be kept short and punchy. */
 "ONBOARDING_APP_SUBTITLE" = "BROWSE BEYOND BORDERS";
 
-/* Body text on one of the on-boarding screens. The intention of this screen is to let the user know that their sites and services -- Facebook, Twitter, etc. -- can be accessed within Psiphon Browser via web pages. */
+/* Body text on one of the on-boarding screens. The intention of this screen is to let the user know that their sites and services -- Facebook, Twitter, etc. -- can be accessed within Psiphon Browser via web pages. DO NOT translate 'Psiphon'. */
 "ONBOARDING_APPS_TEXT" = "Your favorite apps have a web interface that works great in Psiphon Browser";
 
 /* Title text on one of the on-boarding screens. The intention of this screen is to let the user know that their sites and services -- Facebook, Twitter, etc. -- can be accessed within Psiphon Browser via web pages. */
@@ -300,14 +248,8 @@
 /* Alert text telling user which button to press if they want to be redirected to the settings menu */
 "PHOTO_LIBRARY_ACCESS_INSTRUCTION" = "To give permissions tap on 'Change Settings' button";
 
-/* Alert text telling user additional permissions must be granted to save and upload photos in the browser */
+/* Alert text telling user additional permissions must be granted to save and upload photos in the browser. DO NOT translate 'Psiphon'. */
 "PHOTO_LIBRARY_ACCESS_PROMPT" = "\"Psiphon Browser\" needs access to your photo library to save and upload images";
-
-/* Privacy Policy link text */
-"PRIVACY_POLICY_LINK_TEXT" = "Privacy Policy";
-
-/* External link to the privacy policy page. Please update this with the correct language specific link (if available) e.g. https://psiphon.ca/fr/privacy.html for french. */
-"PRIVACY_POLICY_URL" = "https://psiphon.ca/en/privacy.html";
 
 /* UI hint that the webpage can be refreshed by pulling(swiping) down */
 "PULL_TO_REFRESH_PAGE" = "Pull to Refresh Page";
@@ -324,94 +266,22 @@
 /* %ld will be replaced with the number 1 */
 "RULES_IN_USE_SINGULAR" = "%ld rule in use";
 
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_AT" = "Austria";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_BE" = "Belgium";
-
-/* The name of the pseudo-region a user can select if they want to use a Psiphon server with the best performance -- speed, latency, etc., rather than specify a particular region/country. This appears in a combo box and should be kept short. */
-"SERVER_REGION_BEST" = "Best Performance";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_BG" = "Bulgaria";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_CA" = "Canada";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_CH" = "Switzerland";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_CZ" = "Czech Republic";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_DE" = "Germany";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_DK" = "Denmark";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_ES" = "Spain";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_FR" = "France";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_GB" = "United Kingdom";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_HK" = "Hong Kong";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_HU" = "Hungary";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_IN" = "India";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_IT" = "Italy";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_JP" = "Japan";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_NL" = "Netherlands";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_NO" = "Norway";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_RO" = "Romania";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_SE" = "Sweden";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_SG" = "Singapore";
-
-/* Name of a country/region where Psiphon servers are located. The user can choose to only use servers in that country. */
-"SERVER_REGION_US" = "United States";
-
 /* Title of alert to clear local cookies and browsing data */
 "SETTINGS_CLEAR_ALL_COOKIES_PROMPT" = "Remove all cookies and browsing data?";
 
 /* Accept button on alert which triggers clearing all local cookies and browsing data */
 "SETTINGS_CLEAR_ALL_COOKIES_PROMPT_BUTTON" = "Clear Cookies and Data";
 
-/* Title of the settings (aka preferences) view (InAppSettingsKit) */
-"SETTINGS_TITLE" = "Settings";
-
 /* Text of button that user presses to complete onboarding and start tutorial */
 "START_TUTORIAL_BUTTON" = "Start Tutorial";
 
-/* Text on last tutorial screen which prompts the user to exit tutorial and start browsing with Psiphon Browser */
+/* Text on last tutorial screen which prompts the user to exit tutorial and start browsing with Psiphon Browser. DO NOT translate 'Psiphon'. */
 "TUTORIAL_BODY_FINAL" = "Now we'll connect to a Psiphon server so you can start browsing.";
 
 /* Text on second tutorial screen which highlights the settings button */
 "TUTORIAL_BODY_SETTINGS" = "This is where you can access settings and find help";
 
-/* Text on first tutorial screen which highlights the connection indicator */
+/* Text on first tutorial screen which highlights the connection indicator. DO NOT translate 'Psiphon'. */
 "TUTORIAL_BODY_STATUS" = "The green checkmark indicates that Psiphon Browser is connected and ready for you to start browsing";
 
 /* Final button in tutorial which user clicks to exit tutorial and start browsing with Psiphon Browser */

--- a/Endless/en.lproj/Root.strings
+++ b/Endless/en.lproj/Root.strings
@@ -1,6 +1,6 @@
 /* THIS FILE IS GENERATED. DO NOT EDIT. */
 
-/* Settings view subheading for Psiphon-specific settings. */
+/* Settings view subheading for Psiphon-specific settings. DO NOT translate 'Psiphon'. */
 "PSIPHON_BROWSER" = "Psiphon Browser";
 
 /* Settings item text. Leads to options for enabling/disabling sound and vibration on connection status change. */
@@ -24,7 +24,7 @@
 /* Item label for a settings toggle. "Do Not Track" is the standard name for a browser header that opts the user out of sites tracking thing. Text should be kept short. */
 "PRIVACY_DO_NOT_TRACK_LABEL" = "Send \"Do-Not-Track\" requests";
 
-/* Explanatory text for the "Allow Cookies" setting. */
+/* Explanatory text for the "Allow Cookies" setting. DO NOT translate 'Psiphon'. */
 "PRIVACY_ALLOW_COOKIES_DESCRIPTION" = "Manage what types of cookies Psiphon Browser allows.";
 
 /* One of the options for the "Allow Cookies" setting. This text should be kept short. */
@@ -54,7 +54,7 @@
 /* Label for a privacy-related setting. This provides different browser cookie acceptance options, from blocking all cookies to allowing all cookies. This text should be kept short. */
 "PRIVACY_ALLOW_COOKIES_LABEL" = "Allow Cookies";
 
-/* Explanatory text on the "Allow Cookies" setting options page. */
+/* Explanatory text on the "Allow Cookies" setting options page. DO NOT translate 'Psiphon'. */
 "PRIVACY_ALLOW_COOKIES_CHOICES_DESCRIPTION" = "Websites may store cookies and other data on your device to identify you when browsing. This data is usually used to provide services and content specific to you. It can include your login information, preferences, and personal information such as your name or email address. Psiphon Browser blocks cookies from sites other than the one you are visiting (third party cookies) by default to help prevent advertisers from storing data on your device.";
 
 /* Explanatory text for the 'Clear all when backgrounded' privacy setting. */

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ target "Psiphon Browser" do
 
 	pod "InAppSettingsKit", :git => "https://github.com/Psiphon-Inc/InAppSettingsKit.git", :commit => '598c498'
 	#pod "InAppSettingsKit", :path => "../InAppSettingsKit"
-	pod 'PsiphonClientCommonLibrary', :git => "https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git", :commit => 'c6f86c2'
+	pod 'PsiphonClientCommonLibrary', :git => "https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git", :commit => 'd482876'
 	#pod 'PsiphonClientCommonLibrary', :path => "../psiphon-ios-client-common-library/"
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -57,7 +57,7 @@ PODS:
   - MarqueeLabel/ObjC (3.1.2)
   - OCMock (3.3.1)
   - OrderedDictionary (1.4)
-  - PsiphonClientCommonLibrary (0.2.18):
+  - PsiphonClientCommonLibrary (0.2.20):
     - InAppSettingsKit
 
 DEPENDENCIES:
@@ -66,14 +66,14 @@ DEPENDENCIES:
   - MarqueeLabel
   - OCMock
   - OrderedDictionary
-  - PsiphonClientCommonLibrary (from `https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git`, commit `c6f86c2`)
+  - PsiphonClientCommonLibrary (from `https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git`, commit `d482876`)
 
 EXTERNAL SOURCES:
   InAppSettingsKit:
     :commit: 598c498
     :git: https://github.com/Psiphon-Inc/InAppSettingsKit.git
   PsiphonClientCommonLibrary:
-    :commit: c6f86c2
+    :commit: d482876
     :git: https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git
 
 CHECKOUT OPTIONS:
@@ -81,7 +81,7 @@ CHECKOUT OPTIONS:
     :commit: 598c498
     :git: https://github.com/Psiphon-Inc/InAppSettingsKit.git
   PsiphonClientCommonLibrary:
-    :commit: c6f86c2
+    :commit: d482876
     :git: https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git
 
 SPEC CHECKSUMS:
@@ -90,8 +90,8 @@ SPEC CHECKSUMS:
   MarqueeLabel: fcd7057a779422d86589be759036f1510b08c6a0
   OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
   OrderedDictionary: 138c8d2e358d3a0c9adda15c6c7db24e8e3b09e6
-  PsiphonClientCommonLibrary: 58c7a66b526aef97ee46d8ce038241a449a1a1e6
+  PsiphonClientCommonLibrary: 4da4d653e2f0595836985cb61f76c0eab0621ea3
 
-PODFILE CHECKSUM: d75fbba582c44636a6d434854e4de2958b58fe11
+PODFILE CHECKSUM: 50637b36aa539046d82008cc21c0d2d7c96873c3
 
 COCOAPODS: 1.3.1

--- a/i18n_conf.json
+++ b/i18n_conf.json
@@ -1,6 +1,6 @@
 {
     "objcRootDir": ".",
-    "objcIgnoreDirs": [],
+    "objcIgnoreDirs": ["Pods"],
     "plistFiles": [
         "Endless/InAppSettings.bundle/Root.inApp.plist",
         "Endless/InAppSettings.bundle/Privacy.plist",


### PR DESCRIPTION
Part of the work on Psiphon-Inc/psiphon-issues#370.

This mostly involves adding a note to string descriptions.

Also properly exclude Pod code from being included in genstrings. This results in a big reduction of strings in Localizable.strings.